### PR TITLE
fix: gh_canvas(add) applies slider params; gh_script(configure) preserves wires (v1.4.12)

### DIFF
--- a/.prawduct/backlog.md
+++ b/.prawduct/backlog.md
@@ -129,6 +129,27 @@
   area. Doc-audit: if the warning surfaces in tool responses, check `gh_script` ActionInfo + server
   instructions.
 
+- **[GHC-2N8K]** De-duplicate the host-bound slider-apply block shared by gh_canvas add and config
+  `effort: S · impact: S · area: gh-canvas · source: critic · added: 2026-06-24 · status: open · stage: ready · related: GHC-7X4B, GHS-3W9N`
+
+  NOTE from the cumulative Critic review of GHC-7X4B / GHS-3W9N; user asked to track it. The pure
+  decision logic is already shared via `Core/SliderConfig` (`SliderConfig.Plan(...)` → `SliderConfigPlan`),
+  but the ~4-line **host-bound apply step** — set Minimum, then Maximum, then DecimalPlaces (and value)
+  on the live `GH_NumberSlider` — is copy-pasted verbatim in two sites:
+  - `GhCanvasTool.cs` `ActionAdd` (~lines 460-463)
+  - `GhCanvasTool.Values.cs` `ActionConfig` (~lines 125-128)
+
+  **Risk:** low but real — a future change to the apply sequence (e.g. ordering, or a new slider
+  property) could be made in one site and missed in the other.
+
+  **Fix shape:** extract the apply into a single helper (e.g. `SliderConfig.ApplyTo(slider)`, or a small
+  host-side method both call) so add and config share one apply path as well as one plan path.
+
+  Low divergence risk today and no user-facing payoff, so it sat below the earn-the-entry bar until
+  requested. Add and config are currently verified to produce identical sliders by the
+  operator-verification parity check (VRF-004) — that parity is what this item protects against future
+  drift. Doc-audit: internal refactor, behavior-preserving; no user-facing surface expected to change.
+
 ## Promoted
 
 <!-- Items currently being addressed in an active build plan. /backlog pick

--- a/.prawduct/backlog.md
+++ b/.prawduct/backlog.md
@@ -102,7 +102,7 @@
   cap is introduced, check `gh_document` snapshot ActionInfo for the new limit semantics.
 
 - **[GHS-4D8M]** gh_script(set/configure) silently succeeds when it leaves a Script component unable to determine its language (Rhino LanguageSpec wipe — upstream)
-  `effort: M · impact: M · area: gh-script · source: user · added: 2026-06-24 · status: open · stage: ready · related: GHS-7K2P · refs: issue #15`
+  `effort: M · impact: M · area: gh-script · source: user · added: 2026-06-24 · status: open · stage: ready · reviewed: 2026-06-24 · related: GHS-7K2P · refs: issue #15, docs/upstream-rhino-scriptcomponent-languagespec.md`
 
   `gh_script(set/configure)` silently returns `{"success": true}` in a case where it leaves a unified
   `ScriptComponent` unable to determine its language — the component then fails at solve time (the same
@@ -110,12 +110,24 @@
   `languageWarning` guard was added so the tool now surfaces a warning instead of silently reporting
   success (issue #15, partial).
 
-  **Remaining (this item):** the underlying cause — Rhino's `LanguageSpec` being wiped — is upstream in
-  Rhino 8's `ScriptComponent` and is **not** resolved by the guard. This item tracks (a) the remaining
-  upstream LanguageSpec-wipe problem and any cordyceps-side mitigation, and (b) confirming the
-  `languageWarning` guard's coverage. Related to GHS-7K2P (the directive-preservation fix via
-  `Core/ScriptDirective.cs`); distinct mechanism, same `gh-script` area. Doc-audit: if the warning
-  surfaces in tool responses, check `gh_script` ActionInfo + server instructions.
+  **[2026-06-24] Investigation + upstream report drafted.** A McNeel bug report is drafted at
+  `docs/upstream-rhino-scriptcomponent-languagespec.md`, pending filing on McNeel Discourse/YouTrack
+  (next action). Investigation findings:
+  - The unified `ScriptComponent` silently loses its language on a **directive-less `SetSource`** — the
+    error surfaces only at solve time, **not** from `SetSource` itself.
+  - It **IS recoverable** via a directive-bearing `SetSource` — this **corrects the original
+    "permanently broken" claim**.
+  - Setting `LanguageSpec` via reflection **does not stick**.
+
+  **Cordyceps mitigation shipped in v1.4.11:** the `languageWarning` guard + directive preservation
+  (the latter via `Core/ScriptDirective.cs`, GHS-7K2P). The remaining root cause — Rhino's
+  `LanguageSpec` being wiped — is **upstream in Rhino 8's `ScriptComponent` and is not
+  cordyceps-fixable**. This item now tracks the upstream report through filing.
+
+  **Next action:** file the drafted report with McNeel (Discourse / YouTrack). Related to GHS-7K2P
+  (the directive-preservation fix via `Core/ScriptDirective.cs`); distinct mechanism, same `gh-script`
+  area. Doc-audit: if the warning surfaces in tool responses, check `gh_script` ActionInfo + server
+  instructions.
 
 ## Promoted
 
@@ -127,6 +139,73 @@ _(none currently in flight)_
 ## Archive
 
 <!-- Shipped and dropped items, kept for searchability. Never deleted. -->
+
+- **[GHC-7X4B]** gh_canvas(action='add') silently drops slider min/max/value/decimals
+  `effort: S · impact: M · area: gh-canvas · source: user · added: 2026-06-24 · status: shipped · stage: ready · reviewed: 2026-06-24 · closed-by: fix/add-slider-params-and-configure-wires`
+
+  Symptom: `gh_canvas(action='add', type='slider', min=0, max=100, value=50, decimals=2)` ignores
+  min/max/value/decimals. The new Number Slider lands at the default 0–1 range and 0.5 value
+  regardless of what the caller passed.
+
+  Root cause (verified in current source): the public `GhCanvas` method
+  (src/Cordyceps/Tools/Unified/GhCanvasTool.cs:296-298) declares `min`, `max`, `value`, `decimals`
+  as optional parameters, but the `add` dispatcher calls `ActionAdd(type, x, y, nickname)` (~line 367)
+  and `ActionAdd` (~line 401) accepts only those four — the slider params are silently dropped before
+  they reach the component.
+
+  Fix shape (clean-room — mirrors our OWN existing code): forward min/max/value/decimals into
+  ActionAdd, and after `doc.AddObject` apply them to GH_NumberSlider exactly as the existing `config`
+  action already does in GhCanvasTool.Values.cs (ActionConfig). The goal is parity: `add` should
+  configure a slider the same way `config` already can. Non-slider components must ignore the params
+  gracefully.
+
+  Verification: unit test that adds a slider with explicit range/value/decimals and asserts the
+  created slider reflects them; confirm non-slider add still works. Doc audit: the `add` ActionInfo
+  should list min/max/value/decimals as optional with a Tip about slider configuration.
+
+  Acceptance: add-with-slider-params yields a correctly-configured slider; tests + help metadata
+  updated.
+
+  **[2026-06-24] Shipped:** bugfix resolved on branch `fix/add-slider-params-and-configure-wires`
+  (slider params now forwarded into `ActionAdd` and applied via `Core/SliderConfig.cs`).
+  Critic-approved; 224 tests green. Archived as part of the closing PR.
+
+- **[GHS-3W9N]** gh_script(action='configure') destroys all wires instead of preserving by name
+  `effort: M · impact: L · area: gh-script · source: user · added: 2026-06-24 · status: shipped · stage: ready · reviewed: 2026-06-24 · closed-by: fix/add-slider-params-and-configure-wires · related: GHS-4D8M, GHS-7K2P`
+
+  Symptom: `gh_script(action='configure', ...)` drops EVERY wire on the script component — including
+  params whose names did not change — and returns no `lostConnections` array. This silently discards
+  the user's wiring. The sibling `set` action behaves correctly: it keeps wires on name-matched params
+  and reports the rest in `lostConnections`.
+
+  Root cause (verified in current source): `ConfigureViaVariableParams`
+  (src/Cordyceps/Tools/Unified/GhScriptTool.cs:806) unconditionally unregisters every input/output
+  param (~lines 816-825) and re-registers them, so all connections are lost. The `set` path instead
+  routes through the LCS-based `SyncParamSide`/`SyncScriptParams` helper (~lines 528 / 471), which
+  preserves wires on unchanged names and collects removed-param wires into `lostConnections`.
+
+  Fix shape (clean-room — uses our OWN existing helper): make `configure` perform its param sync
+  through the same `SyncParamSide` helper that `set` already uses, so unchanged-name params keep their
+  wires and removed-param wires surface in `lostConnections` (identical response shape to `set`,
+  directly usable with gh_wire(action='connect') to restore). Target: configure and set should
+  preserve wiring identically.
+
+  Open design question (decide during build, from our own API surface — not required for the core fix):
+  should `configure` be a true partial update that distinguishes "param side omitted → leave it alone"
+  from "empty list passed → clear that side"? Flag it; don't assume.
+
+  Verification: regression test — configure a script that already has wires, assert name-matched params
+  keep wires and removed params appear in lostConnections. Doc audit: the `configure` ActionInfo Tips
+  and Knowledge/GettingStartedGuide.md should describe wire preservation + lostConnections (today only
+  `set` is documented — GettingStartedGuide.md:37).
+
+  Acceptance: configure preserves wires like set; lostConnections returned for dropped params;
+  regression test + docs/help updated.
+
+  **[2026-06-24] Shipped:** bugfix resolved on branch `fix/add-slider-params-and-configure-wires`
+  (`configure` now syncs params through the shared LCS helper, preserving name-matched wires and
+  surfacing removed-param wires in `lostConnections`; see `Core/ParamSyncPlan.cs`). Critic-approved;
+  224 tests green. Archived as part of the closing PR.
 
 - **[GHD-8P4N]** gh_document(save) cannot overwrite an existing .gh file
   `effort: S · impact: M · area: gh-document · source: user · added: 2026-06-24 · status: shipped · stage: ready · reviewed: 2026-06-24 · closed-by: gh-document-save · refs: issue #14`

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -39,6 +39,32 @@
      derived view. Don't hand-edit them — add/update a tagged entry here and
      run `prawduct-hook regen-views`. -->
 
+## 2026-06-24: slider add-params + configure wire-preservation (v1.4.12)
+
+<!-- prawduct: type=bugfix | scope=gh-canvas-slider-add -->
+
+**Why:** `gh_canvas(action='add', type='slider', ...)` silently dropped min/max/value/decimals —
+the `add` dispatcher forwarded only type/x/y/nickname to `ActionAdd`, so a new slider always
+landed at the default 0–1 range / 0.5 value regardless of args, forcing a second `config` call.
+The slider-config decision is now a pure host-free helper (`Core/SliderConfig.cs`, parsing the
+value with InvariantCulture — a latent locale fix) shared by both `add` (applied after
+`AddObject` when the new object is a `GH_NumberSlider`: range first, then value so it isn't
+clamped to the old range) and `config` (refactored for parity). 19 unit tests incl. the
+dropped-params regression; non-slider adds ignore the params. Host glue queued for operator
+verification (VRF-004). (GHC-7X4B)
+
+<!-- prawduct: type=bugfix | scope=gh-script-configure-wires -->
+
+**Why:** `gh_script(action='configure')` unregistered every input/output param and re-registered
+them from scratch (`ConfigureViaVariableParams`), silently destroying ALL wires — even on
+name-unchanged params — and reported nothing lost. It now reshapes params by name via the same
+LCS sync `set` already used, extracted to a pure helper (`Core/ParamSyncPlan.cs`): name-matched
+params keep their connections; wires on renamed/removed params return in a `lostConnections` array
+(with a `reconnectHint`) usable directly with `gh_wire(action='connect')`. `configure` is now also
+a partial update — omit a side to leave it untouched, pass `[]` to clear it (previously,
+configuring only `inputs` wiped all `outputs`). 10 unit tests; host glue queued for operator
+verification (VRF-005). (GHS-3W9N)
+
 ## 2026-06-24: gh_script(set) flags a silently-broken Script component (issue #15)
 
 <!-- prawduct: type=bugfix | scope=gh-script-language | status=merged -->

--- a/.prawduct/learnings.md
+++ b/.prawduct/learnings.md
@@ -22,6 +22,19 @@ local-progress gesture is view↔tag drift (the Critic flags it; regen-views wou
 **Track in-flight progress in the `## Status` Context prose**, not by editing the boxes. (Recurred:
 the MCP-4R2K plan did it, then the backlog-batch plan copied it — Critic-caught both times.)
 
+## Refresh stale `.test-evidence.json` via the hook, not by hand
+
+The cumulative-Critic staleness check and the `test-status` gate READ
+`.prawduct/.test-evidence.json`; the WRITER is `prawduct-hook test-evidence record` (a real run +
+ISO timestamp + F4a coverage overlay). **Don't hand-edit the JSON** — the hook's own docstring notes
+"every product repo improvised a hand-written JSON," which is exactly what drifts. Gotcha: this repo
+declares `test_command:` in `project-state.yaml`, so `record --from-junit <report>` is **rejected**
+(it would be two runners — the declared command vs. an ingested report). Just run
+`python3 <plugin>/bin/prawduct-hook test-evidence record` and it runs the declared command itself
+(substituting `{junit_xml}`), stamps the timestamp, and merges coverage. Note the `changes_*` fields
+will list every C# file under `changes_unjudged` — the floor verifier is Python-only symbol-grep, so
+that's structurally expected here, not a coverage failure.
+
 ## Building dirties the tracked `releases/Cordyceps.gha` binary
 
 `Cordyceps.csproj` has a post-build `CopyToReleases` target that copies the built `.gha`

--- a/.prawduct/operator-verification.md
+++ b/.prawduct/operator-verification.md
@@ -75,3 +75,47 @@ on-UI-thread snapshot write without error. The build agent has no headless Rhino
 - **Snapshot list is stable under concurrency:** create a snapshot (`gh_document(action='snapshot')`)
   and, around the same time, list snapshots (`gh_document(action='snapshots')`). Expected: listing
   returns the current set with no exception and no corrupt/partial entry, regardless of timing.
+
+## VRF-004 — Chunk 1 (GHC-7X4B) — Slider params applied on `add`
+
+**Status:** pending
+**Added:** 2026-06-24 (Chunk 1, slider-add-params)
+**Where to verify:** Rhino 8 + Grasshopper with the Cordyceps component placed and an MCP client connected.
+
+**Why this needs a human:** The decision logic (`Core/SliderConfig` — which settings to apply, parsed
+with InvariantCulture) is unit-tested in CI, but the host glue — applying the plan to a live
+`GH_NumberSlider` after `doc.AddObject` (set range, then value so it isn't clamped to the old range,
+then decimals) — only runs with a real Grasshopper document. The build agent has no headless Rhino.
+
+**Verify:**
+- **Add applies all four:** `gh_canvas(action='add', type='slider', min=0, max=100, value=50, decimals=2)`.
+  Expected: the new slider on the canvas reads **0–100**, value **50**, **2** decimals — in a single
+  call, no follow-up `action='config'`. Before this fix it landed at the default 0–1 / 0.5.
+- **Range-before-value ordering:** add a slider with `min=10, max=20, value=15`. Expected value is
+  **15**, not clamped to a stale 0–1 range.
+- **Non-slider unaffected:** `gh_canvas(action='add', type='panel', ...)` (or any non-slider) with the
+  same params present ignores them and adds normally.
+- **Parity with config:** a slider added with these params matches one added plain then `action='config'`-ed
+  to the same values.
+
+## VRF-005 — Chunk 2 (GHS-3W9N) — `configure` preserves wires; partial-update semantics
+
+**Status:** pending
+**Added:** 2026-06-24 (Chunk 2, configure-wire-preservation)
+**Where to verify:** Rhino 8 + Grasshopper with a C#/Python script component wired on both sides, MCP client connected.
+
+**Why this needs a human:** The LCS diff (`Core/ParamSyncPlan` — keep/remove/insert by name) is
+unit-tested in CI, but the host glue — reshaping live `IGH_Param` registration from the plan, carrying
+existing wires across name-matched params, collecting removed-param wires into `lostConnections`, and
+applying type hints + access — only exists with a running Grasshopper document.
+
+**Verify:** (script component with inputs **and** outputs both wired)
+- **Name-matched wires survive:** `configure` a side keeping a param's name. Expected: that param's
+  wire is still connected after; no silent drop. Before this fix `configure` wiped **every** wire.
+- **Partial update — omit a side:** `configure` passing only `inputs` (omit `outputs`). Expected:
+  outputs **and their wires** are left untouched. Before this fix configuring inputs wiped outputs.
+- **Explicit clear — `[]`:** `configure` passing `outputs=[]`. Expected: outputs cleared and their
+  wires returned in `lostConnections`.
+- **Rename reports + reconnects:** rename an input. Expected: its old wire appears in `lostConnections`
+  with a `reconnectHint`, and that hint is directly usable with `gh_wire(action='connect')` to restore it.
+- **Response shape matches `set`:** `lostConnections` + `reconnectHint` look identical to what `set` returns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`gh_canvas(action='add')` now applies slider min/max/value/decimals** - Adding a Number Slider with `gh_canvas(action='add', type='slider', min=0, max=100, value=50, decimals=2)` previously ignored all four configuration params — the slider always landed at the default 0–1 range and 0.5 value, forcing a second `action='config'` call. The `add` dispatcher dropped the params before they reached the component. They are now applied on add (range first, then value, so the value isn't clamped to the old range), giving `add` parity with `config`; both share one `Core.SliderConfig` policy. Non-slider components ignore these params. (GHC-7X4B)
+- **`gh_script(action='configure')` now preserves wires instead of destroying them** - `configure` previously unregistered *every* input and output parameter and re-registered them from scratch, so it silently dropped **all** wires on the component — even on parameters whose name didn't change — and returned no record of what was lost. It now reshapes parameters by name using the same LCS sync that `set` already used: parameters matching by name keep their connections, and wires on renamed/removed parameters are returned in a `lostConnections` array (with a `reconnectHint`), directly usable with `gh_wire(action='connect')` to restore them. `configure` is now also a **partial update** — omit a side (don't pass `inputs`/`outputs`) to leave it untouched, or pass `[]` to explicitly clear that side; previously, configuring only `inputs` would wipe all `outputs`. (GHS-3W9N)
+
 ## [1.4.11] - 2026-06-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Cordyceps will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.4.12] - 2026-06-24
 
 ### Fixed
 

--- a/docs/upstream-rhino-scriptcomponent-languagespec.md
+++ b/docs/upstream-rhino-scriptcomponent-languagespec.md
@@ -1,0 +1,120 @@
+# Upstream bug report (McNeel): unified `ScriptComponent` silently loses its language on source replacement
+
+This is a **draft to file with McNeel** (Rhino/Grasshopper), not a Cordyceps bug. Cordyceps
+already mitigates the reachable cases (see *Cordyceps mitigation* below); the root cause is in
+Rhino 8's `RhinoCodePluginGH.Components.ScriptComponent`. Backlog: `GHS-4D8M`. Originally surfaced
+in Cordyceps issue [#15](https://github.com/brookstalley/cordyceps/issues/15).
+
+**Where to file:** McNeel Discourse (https://discourse.mcneel.com/, *Grasshopper Developer* /
+*Scripting* category) or, if you have an account, YouTrack (https://mcneel.myjetbrains.com/).
+
+---
+
+## Summary
+
+Replacing the source of the **unified "Script" component**
+(`RhinoCodePluginGH.Components.ScriptComponent`, ComponentGuid
+`c9b2d725-6f87-4b07-af90-bd9aefef68eb`) with a body that lacks a first-line language directive
+(`#! python 3`, `// #! csharp`) leaves the component **unable to determine its language**. At the
+next solution it fails with the runtime error **"Can not determine input code language"** and
+emits no output. The source-setting call (`BaseScriptComponent.SetSource(string)` /
+`IScriptComponent.Text`) **returns no error or warning** — the failure surfaces only at solve
+time — so an automation/API caller has no synchronous signal that it just broke the component.
+
+The dedicated **"C# Script"** component
+(`RhinoCodePluginGH.Components.CSharpComponent`, ComponentGuid `b6ba1144-…`) is **not** affected:
+it carries a concrete `LanguageSpec` and continues to compile through the same directive-less
+`SetSource` call.
+
+## Environment
+
+- Rhino 8 (reproduced on 8.31, macOS; the mechanism is platform-independent — it is in the
+  Grasshopper scripting plug-in, driven through the public component API).
+- Grasshopper, `RhinoCodePluginGH` / `RhinoCodePlatform.GH`.
+- Reproduced both through a third-party MCP bridge (Cordyceps) and, in the original report, via
+  direct reflection on the component instance.
+
+## The two component classes
+
+Rhino 8 ships two .NET classes that both present as "a script component" in the GH UI:
+
+| Toolbar entry | Class (`Type.FullName`) | ComponentGuid | Baseline `LanguageSpec` |
+|---|---|---|---|
+| **Script** (pick language on the component) | `RhinoCodePluginGH.Components.ScriptComponent` | `c9b2d725-…` | all-wildcard `*.*.*@*.*` until a language is chosen |
+| **C# Script** (dedicated) | `RhinoCodePluginGH.Components.CSharpComponent` | `b6ba1144-…` | `*.*.csharp@*.*` (language slot fixed) |
+
+Both derive from `BaseScriptComponent<,>` and implement `RhinoCodePlatform.GH.IScriptComponent`;
+they share `SetSource(string)`. The difference in behavior below traces to the `ScriptComponent`
+variant having no concrete language slot of its own — it infers the language from the source's
+first-line directive — while `CSharpComponent` has the language baked into its `LanguageSpec`.
+
+## Reproduction (API / automation)
+
+1. Add a unified **Script** component (`c9b2d725-…`) to the document. Freshly added, it has no
+   language: `RuntimeMessageLevel = Warning`, message *"No script to execute. Choose a language
+   from component menu."* (`LanguageSpec = *.*.*@*.*`).
+2. Set its source to a body **without** a directive, e.g. `a = 42` (or
+   `private void RunScript(object x, ref object A){ A = x; }`), via `SetSource(...)` /
+   `IScriptComponent.Text`.
+   - **The call returns normally — no exception, no error, no warning.**
+3. Let the document solve. The component now reports
+   `RuntimeMessageLevel = Error`, message **"Can not determine input code language"**, and
+   produces no output.
+
+Observed timing: with the solver **disabled**, step 2 leaves the component showing no error
+(`RuntimeMessageLevel = Blank`); the error only materializes when a solution actually runs
+(i.e. it is raised in `SolveInstance`, not by `SetSource`). This is why the failure is invisible
+to a caller that just sets source and checks the immediate return value.
+
+## Expected vs. actual
+
+- **Expected:** either (a) `SetSource` keeps/derives a usable language for a `ScriptComponent`
+  that previously had one (or had a directive), or (b) the failure to determine a language is
+  reported **at the point of the call**, not silently deferred to solve time.
+- **Actual:** the language association is lost silently; the only signal is a solve-time runtime
+  error, and the component emits nothing.
+
+## `LanguageSpec` observations (from the original reporter, reflection-verified)
+
+From Cordyceps issue #15 (verified by the reporter via reflection on the live instance — included
+here for McNeel's benefit, attributed, not independently re-derived in this write-up):
+
+- For a `ScriptComponent` that had a concrete spec (e.g. `C# 9.0 (mcneel.roslyn.csharp)`), the
+  same source replacement wiped `IScriptComponent.LanguageSpec` to the all-wildcard `*.*.*@*.*`.
+- Writing `LanguageSpec` back via reflection (e.g. to `LanguageSpec.CSharp`) **did not stick** —
+  the setter ran without error but a subsequent read returned `*.*.*@*.*` again. So there is no
+  API-only "restore the spec" repair path.
+
+## Recovery (corrects the original "permanently broken" claim)
+
+While the `LanguageSpec` *property* cannot be restored via reflection, the component **is
+recoverable** through the normal source path: calling `SetSource` with a body whose **first line
+is a directive** (`#! python 3` / `#! python 2` / `// #! csharp`) makes it compile again. A
+component previously left in the *"Can not determine input code language"* error state returns to
+healthy (`RuntimeMessageLevel = Blank`) after a directive-bearing `SetSource`. So the practical
+problem is not unrecoverability — it is the **silent loss** of language on a directive-less set,
+with no signal until solve time.
+
+## Suggested fix (McNeel)
+
+Any one of these would resolve the user-facing problem:
+
+1. When `ScriptComponent.SetSource` receives a body with no language directive, **retain the
+   component's current language** instead of resetting `LanguageSpec` to all-wildcard.
+2. If a language genuinely cannot be determined, **surface it from `SetSource`** (return value or
+   a runtime message set immediately) rather than only at solve time — so API callers can detect
+   it.
+3. Make `set IScriptComponent.LanguageSpec` actually persist, giving programmatic callers a
+   reliable way to set/restore the language.
+
+## Cordyceps mitigation (for context — not part of the McNeel ask)
+
+Cordyceps cannot fix the Rhino-side behavior, but as of v1.4.11 it no longer hides it:
+
+- `gh_script(set/configure)` **preserves an existing first-line directive** when the new body
+  omits one (so a component whose source already carries `#! …` keeps its language across
+  updates).
+- When the final source still has no directive on a unified `ScriptComponent`, the tool returns a
+  **`languageWarning`** telling the caller to start the body with `#! python 3` / `// #! csharp`
+  (which also recovers a component already in the broken state), instead of silently reporting
+  success.

--- a/src/Cordyceps.Tests/Cordyceps.Tests.csproj
+++ b/src/Cordyceps.Tests/Cordyceps.Tests.csproj
@@ -28,6 +28,8 @@
     <Compile Include="..\Cordyceps\Core\CommandStats.cs" Link="CommandStats.cs" />
     <Compile Include="..\Cordyceps\Core\ScriptDirective.cs" Link="ScriptDirective.cs" />
     <Compile Include="..\Cordyceps\Core\GhArchiveSave.cs" Link="GhArchiveSave.cs" />
+    <Compile Include="..\Cordyceps\Core\SliderConfig.cs" Link="SliderConfig.cs" />
+    <Compile Include="..\Cordyceps\Core\ParamSyncPlan.cs" Link="ParamSyncPlan.cs" />
     <Compile Include="..\Cordyceps\Core\McpResultFormatter.cs" Link="McpResultFormatter.cs" />
     <Compile Include="..\Cordyceps\Core\RequestValidator.cs" Link="RequestValidator.cs" />
     <Compile Include="..\Cordyceps\Core\UnifiedToolHelpers.cs" Link="UnifiedToolHelpers.cs" />

--- a/src/Cordyceps.Tests/ParamSyncPlanTests.cs
+++ b/src/Cordyceps.Tests/ParamSyncPlanTests.cs
@@ -1,0 +1,143 @@
+using System.Linq;
+using Cordyceps.Core;
+using Xunit;
+
+namespace Cordyceps.Tests
+{
+    /// <summary>
+    /// Unit tests for <see cref="ParamSyncPlan"/>, the host-free LCS diff that lets both
+    /// <c>gh_script(action='set')</c> and <c>gh_script(action='configure')</c> reshape a component's
+    /// parameters while preserving wires on name-matched params. The defining regression (GHS-3W9N)
+    /// is that <c>configure</c> used to remove EVERY param — even unchanged-name ones — losing all
+    /// wires; <see cref="Compute_UnchangedNames_KeepsAll_NoRemovals"/> and
+    /// <see cref="Compute_PreservesMatchedNames_RemovesOnlyChanged"/> pin the fixed behavior.
+    /// </summary>
+    public class ParamSyncPlanTests
+    {
+        private static string[] NamesAt(ParamSyncPlan plan, string[] existing, System.Collections.Generic.IReadOnlyList<int> indices)
+            => indices.Select(i => existing[i]).ToArray();
+
+        [Fact]
+        public void Compute_UnchangedNames_KeepsAll_NoRemovals()
+        {
+            var existing = new[] { "a", "b", "c" };
+            var plan = ParamSyncPlan.Compute(existing, new[] { "a", "b", "c" });
+
+            Assert.True(plan.IsNoOp);
+            Assert.Empty(plan.RemoveExistingIndicesDescending);
+            Assert.Empty(plan.Insertions);
+            Assert.Equal(new[] { 0, 1, 2 }, plan.KeptExistingIndices);
+        }
+
+        [Fact]
+        public void Compute_PreservesMatchedNames_RemovesOnlyChanged()
+        {
+            // existing [a,b,c] -> target [a,c]: 'b' removed, 'a' and 'c' keep their wires.
+            var existing = new[] { "a", "b", "c" };
+            var plan = ParamSyncPlan.Compute(existing, new[] { "a", "c" });
+
+            Assert.False(plan.IsNoOp);
+            Assert.Equal(new[] { "b" }, NamesAt(plan, existing, plan.RemoveExistingIndicesDescending));
+            Assert.Empty(plan.Insertions);
+            // a (0) and c (2) are kept in place — their connections are preserved.
+            Assert.Equal(new[] { 0, 2 }, plan.KeptExistingIndices);
+        }
+
+        [Fact]
+        public void Compute_AddsNewParam_InsertsAtTargetPosition()
+        {
+            // existing [a,b] -> target [a,b,c]: insert 'c' at index 2; nothing removed.
+            var plan = ParamSyncPlan.Compute(new[] { "a", "b" }, new[] { "a", "b", "c" });
+
+            Assert.Empty(plan.RemoveExistingIndicesDescending);
+            var insert = Assert.Single(plan.Insertions);
+            Assert.Equal(2, insert.TargetIndex);
+            Assert.Equal("c", insert.Name);
+        }
+
+        [Fact]
+        public void Compute_InsertInMiddle_HasCorrectTargetIndex()
+        {
+            // existing [a,c] -> target [a,b,c]: insert 'b' at index 1; a and c kept.
+            var plan = ParamSyncPlan.Compute(new[] { "a", "c" }, new[] { "a", "b", "c" });
+
+            Assert.Empty(plan.RemoveExistingIndicesDescending);
+            var insert = Assert.Single(plan.Insertions);
+            Assert.Equal(1, insert.TargetIndex);
+            Assert.Equal("b", insert.Name);
+        }
+
+        [Fact]
+        public void Compute_Rename_RemovesOldInsertsNew()
+        {
+            // A rename has no name in common: 'a' removed, 'x' inserted — the wire on 'a' is lost.
+            var existing = new[] { "a" };
+            var plan = ParamSyncPlan.Compute(existing, new[] { "x" });
+
+            Assert.Equal(new[] { "a" }, NamesAt(plan, existing, plan.RemoveExistingIndicesDescending));
+            var insert = Assert.Single(plan.Insertions);
+            Assert.Equal(0, insert.TargetIndex);
+            Assert.Equal("x", insert.Name);
+            Assert.Empty(plan.KeptExistingIndices);
+        }
+
+        [Fact]
+        public void Compute_ClearAll_RemovesEverything_DescendingOrder()
+        {
+            // target empty (the "empty list -> clear that side" case): all removed, descending.
+            var plan = ParamSyncPlan.Compute(new[] { "a", "b", "c" }, new string[0]);
+
+            Assert.Equal(new[] { 2, 1, 0 }, plan.RemoveExistingIndicesDescending);
+            Assert.Empty(plan.Insertions);
+            Assert.Empty(plan.KeptExistingIndices);
+        }
+
+        [Fact]
+        public void Compute_FromEmpty_InsertsAllAscending()
+        {
+            var plan = ParamSyncPlan.Compute(new string[0], new[] { "a", "b" });
+
+            Assert.Empty(plan.RemoveExistingIndicesDescending);
+            Assert.Equal(new[] { 0, 1 }, plan.Insertions.Select(i => i.TargetIndex).ToArray());
+            Assert.Equal(new[] { "a", "b" }, plan.Insertions.Select(i => i.Name).ToArray());
+        }
+
+        [Fact]
+        public void Compute_RemovalIndices_AreStrictlyDescending()
+        {
+            // Descending order is the contract that lets the host unregister without index shifts.
+            var plan = ParamSyncPlan.Compute(new[] { "a", "b", "c", "d", "e" }, new[] { "a", "d" });
+
+            var removes = plan.RemoveExistingIndicesDescending;
+            for (int i = 1; i < removes.Count; i++)
+                Assert.True(removes[i] < removes[i - 1], "remove indices must be strictly descending");
+        }
+
+        [Fact]
+        public void Compute_PartialOverlap_KeepsCommonSubsequence()
+        {
+            // existing [a,b,c,d] -> target [b,d,e]: keep b,d (wires preserved); remove a,c; insert e.
+            var existing = new[] { "a", "b", "c", "d" };
+            var plan = ParamSyncPlan.Compute(existing, new[] { "b", "d", "e" });
+
+            Assert.Equal(new[] { "c", "a" }, NamesAt(plan, existing, plan.RemoveExistingIndicesDescending));
+            Assert.Equal(new[] { 1, 3 }, plan.KeptExistingIndices); // b, d
+            var insert = Assert.Single(plan.Insertions);
+            Assert.Equal(2, insert.TargetIndex);
+            Assert.Equal("e", insert.Name);
+        }
+
+        [Fact]
+        public void Compute_NullLists_TreatedAsEmpty()
+        {
+            var plan = ParamSyncPlan.Compute(null, null);
+            Assert.True(plan.IsNoOp);
+
+            var insertOnly = ParamSyncPlan.Compute(null, new[] { "a" });
+            Assert.Single(insertOnly.Insertions);
+
+            var removeOnly = ParamSyncPlan.Compute(new[] { "a" }, null);
+            Assert.Equal(new[] { 0 }, removeOnly.RemoveExistingIndicesDescending);
+        }
+    }
+}

--- a/src/Cordyceps.Tests/SliderConfigTests.cs
+++ b/src/Cordyceps.Tests/SliderConfigTests.cs
@@ -1,0 +1,128 @@
+using Cordyceps.Core;
+using Xunit;
+
+namespace Cordyceps.Tests
+{
+    /// <summary>
+    /// Unit tests for <see cref="SliderConfig"/>, the host-free policy that both
+    /// <c>gh_canvas(action='add')</c> and <c>gh_canvas(action='config')</c> use to decide which
+    /// Number Slider settings to apply. The defining regression (GHC-7X4B) is that <c>add</c> used
+    /// to drop min/max/value/decimals entirely — covered by <see cref="Plan_WithAllParams_AppliesAll"/>.
+    /// </summary>
+    public class SliderConfigTests
+    {
+        // Sentinels matching the gh_canvas tool's parameter defaults for "not provided".
+        private const double NoMin = double.NaN;
+        private const double NoMax = double.NaN;
+        private const int NoDecimals = -1;
+        private const string NoValue = null;
+
+        [Fact]
+        public void Plan_WithAllParams_AppliesAll()
+        {
+            // GHC-7X4B regression: add(slider, min=0, max=100, value=50, decimals=2) must carry all four.
+            var plan = SliderConfig.Plan(min: 0, max: 100, value: "50", decimals: 2);
+
+            Assert.True(plan.HasAny);
+            Assert.True(plan.SetMinimum);
+            Assert.Equal(0m, plan.Minimum);
+            Assert.True(plan.SetMaximum);
+            Assert.Equal(100m, plan.Maximum);
+            Assert.True(plan.SetDecimals);
+            Assert.Equal(2, plan.Decimals);
+            Assert.True(plan.SetValue);
+            Assert.Equal(50m, plan.Value);
+        }
+
+        [Fact]
+        public void Plan_WithNoParams_AppliesNothing()
+        {
+            // A plain add (no slider params) must leave the slider at its component defaults.
+            var plan = SliderConfig.Plan(NoMin, NoMax, NoValue, NoDecimals);
+
+            Assert.False(plan.HasAny);
+            Assert.False(plan.SetMinimum);
+            Assert.False(plan.SetMaximum);
+            Assert.False(plan.SetDecimals);
+            Assert.False(plan.SetValue);
+        }
+
+        [Fact]
+        public void Plan_OnlyMin_AppliesOnlyMin()
+        {
+            var plan = SliderConfig.Plan(min: 5, max: NoMax, value: NoValue, decimals: NoDecimals);
+
+            Assert.True(plan.SetMinimum);
+            Assert.Equal(5m, plan.Minimum);
+            Assert.False(plan.SetMaximum);
+            Assert.False(plan.SetDecimals);
+            Assert.False(plan.SetValue);
+        }
+
+        [Fact]
+        public void Plan_OnlyMax_AppliesOnlyMax()
+        {
+            var plan = SliderConfig.Plan(min: NoMin, max: 42, value: NoValue, decimals: NoDecimals);
+
+            Assert.False(plan.SetMinimum);
+            Assert.True(plan.SetMaximum);
+            Assert.Equal(42m, plan.Maximum);
+            Assert.False(plan.SetDecimals);
+            Assert.False(plan.SetValue);
+        }
+
+        [Theory]
+        [InlineData(0, true)]
+        [InlineData(2, true)]
+        [InlineData(10, true)]
+        [InlineData(-1, false)]   // sentinel: not provided
+        [InlineData(-5, false)]   // any negative is "not provided"
+        public void Plan_Decimals_HonorsNonNegativeSentinel(int decimals, bool expectedSet)
+        {
+            var plan = SliderConfig.Plan(NoMin, NoMax, NoValue, decimals);
+
+            Assert.Equal(expectedSet, plan.SetDecimals);
+            if (expectedSet)
+                Assert.Equal(decimals, plan.Decimals);
+        }
+
+        [Theory]
+        [InlineData("50", true, 50)]
+        [InlineData("3.14", true, 3.14)]      // invariant decimal point parses regardless of locale
+        [InlineData("-7.5", true, -7.5)]
+        [InlineData("0", true, 0)]
+        [InlineData(null, false, 0)]
+        [InlineData("", false, 0)]
+        [InlineData("abc", false, 0)]         // non-numeric → left as-is, no throw
+        [InlineData("   ", false, 0)]
+        public void Plan_Value_ParsedOnlyWhenNumeric(string value, bool expectedSet, double expected)
+        {
+            var plan = SliderConfig.Plan(NoMin, NoMax, value, NoDecimals);
+
+            Assert.Equal(expectedSet, plan.SetValue);
+            if (expectedSet)
+                Assert.Equal((decimal)expected, plan.Value);
+        }
+
+        [Fact]
+        public void Plan_NegativeRange_IsApplied()
+        {
+            // Negative min/max are valid slider bounds — NaN is the only "not provided" signal.
+            var plan = SliderConfig.Plan(min: -100, max: -10, value: NoValue, decimals: NoDecimals);
+
+            Assert.True(plan.SetMinimum);
+            Assert.Equal(-100m, plan.Minimum);
+            Assert.True(plan.SetMaximum);
+            Assert.Equal(-10m, plan.Maximum);
+        }
+
+        [Fact]
+        public void Plan_FractionalBounds_PreservedAsDecimal()
+        {
+            var plan = SliderConfig.Plan(min: 0.25, max: 9.75, value: NoValue, decimals: NoDecimals);
+
+            Assert.Equal(0.25m, plan.Minimum);
+            Assert.Equal(9.75m, plan.Maximum);
+        }
+    }
+}

--- a/src/Cordyceps/Core/ParamSyncPlan.cs
+++ b/src/Cordyceps/Core/ParamSyncPlan.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cordyceps.Core
+{
+    /// <summary>
+    /// Pure, host-free diff that decides how to reshape one side (inputs or outputs) of a script
+    /// component's parameters so its names match a target list, while preserving as many existing
+    /// parameters — and therefore their wires — as possible.
+    ///
+    /// <para>The strategy is a Longest Common Subsequence (LCS) over the parameter <em>names</em>:
+    /// parameters whose names appear in both the existing and target lists are kept in place (their
+    /// connections survive); the rest are removed, and missing target names are inserted. This is the
+    /// single source of truth shared by <c>gh_script(action='set')</c> and
+    /// <c>gh_script(action='configure')</c>. <c>configure</c> historically unregistered <em>every</em>
+    /// parameter and re-registered it, destroying all wires even on unchanged-name params (GHS-3W9N);
+    /// routing it through this plan gives it the same wire preservation <c>set</c> already had.</para>
+    ///
+    /// <para>Indices are relative to the <em>custom</em> portion of the side — the caller skips any
+    /// built-in leading parameter (e.g. a C#/Python script's index-0 <c>out</c> output) before
+    /// computing the plan and adds that skip count back when touching the live parameter list.
+    /// Kept by the host (not here): capturing the wires of removed params and creating/registering
+    /// the inserted ones.</para>
+    /// </summary>
+    public sealed class ParamSyncPlan
+    {
+        private ParamSyncPlan(
+            IReadOnlyList<int> removeExistingIndicesDescending,
+            IReadOnlyList<ParamInsertion> insertions,
+            IReadOnlyList<int> keptExistingIndices)
+        {
+            RemoveExistingIndicesDescending = removeExistingIndicesDescending;
+            Insertions = insertions;
+            KeptExistingIndices = keptExistingIndices;
+        }
+
+        /// <summary>
+        /// Existing-list indices to remove, in descending order so the host can unregister them
+        /// without shifting the indices of not-yet-removed params. The wires on these params are the
+        /// ones reported as lost.
+        /// </summary>
+        public IReadOnlyList<int> RemoveExistingIndicesDescending { get; }
+
+        /// <summary>
+        /// New params to insert, in ascending target order. Applying them left-to-right after the
+        /// removals places each at its final position (earlier insertions account for later ones).
+        /// </summary>
+        public IReadOnlyList<ParamInsertion> Insertions { get; }
+
+        /// <summary>Existing-list indices that are kept in place (the LCS), ascending.</summary>
+        public IReadOnlyList<int> KeptExistingIndices { get; }
+
+        /// <summary>True when the existing names already equal the target names — nothing to do.</summary>
+        public bool IsNoOp => RemoveExistingIndicesDescending.Count == 0 && Insertions.Count == 0;
+
+        /// <summary>
+        /// Compute the keep/remove/insert plan to turn <paramref name="existingNames"/> into
+        /// <paramref name="targetNames"/>, maximizing preserved (kept) params via LCS.
+        /// </summary>
+        public static ParamSyncPlan Compute(IReadOnlyList<string> existingNames, IReadOnlyList<string> targetNames)
+        {
+            existingNames ??= Array.Empty<string>();
+            targetNames ??= Array.Empty<string>();
+
+            var matches = ComputeLcs(existingNames, targetNames);
+            var keepExistingIdx = new HashSet<int>(matches.Select(m => m.existIdx));
+            var lcsTargetIdx = new HashSet<int>(matches.Select(m => m.targetIdx));
+
+            // Removals: existing indices not in the LCS, descending for shift-safe unregistering.
+            var removes = new List<int>();
+            for (int i = existingNames.Count - 1; i >= 0; i--)
+            {
+                if (!keepExistingIdx.Contains(i))
+                    removes.Add(i);
+            }
+
+            // Insertions: target positions not covered by the LCS, ascending.
+            var inserts = new List<ParamInsertion>();
+            for (int t = 0; t < targetNames.Count; t++)
+            {
+                if (!lcsTargetIdx.Contains(t))
+                    inserts.Add(new ParamInsertion(t, targetNames[t]));
+            }
+
+            var kept = matches.Select(m => m.existIdx).OrderBy(i => i).ToList();
+
+            return new ParamSyncPlan(removes, inserts, kept);
+        }
+
+        /// <summary>
+        /// Longest Common Subsequence of two name lists, returned as (existing index, target index)
+        /// pairs for matched elements in order. Unchanged from the original SyncParamSide algorithm,
+        /// so routing the live sync through this plan is behavior-preserving.
+        /// </summary>
+        private static List<(int existIdx, int targetIdx)> ComputeLcs(IReadOnlyList<string> existing, IReadOnlyList<string> target)
+        {
+            int m = existing.Count, n = target.Count;
+            var dp = new int[m + 1, n + 1];
+
+            for (int i = 1; i <= m; i++)
+                for (int j = 1; j <= n; j++)
+                    dp[i, j] = existing[i - 1] == target[j - 1]
+                        ? dp[i - 1, j - 1] + 1
+                        : Math.Max(dp[i - 1, j], dp[i, j - 1]);
+
+            var matches = new List<(int, int)>();
+            int x = m, y = n;
+            while (x > 0 && y > 0)
+            {
+                if (existing[x - 1] == target[y - 1])
+                {
+                    matches.Add((x - 1, y - 1));
+                    x--; y--;
+                }
+                else if (dp[x - 1, y] >= dp[x, y - 1])
+                    x--;
+                else
+                    y--;
+            }
+
+            matches.Reverse();
+            return matches;
+        }
+    }
+
+    /// <summary>A parameter to insert at <see cref="TargetIndex"/> (relative to the custom portion).</summary>
+    public readonly struct ParamInsertion
+    {
+        public ParamInsertion(int targetIndex, string name)
+        {
+            TargetIndex = targetIndex;
+            Name = name;
+        }
+
+        public int TargetIndex { get; }
+        public string Name { get; }
+    }
+}

--- a/src/Cordyceps/Core/SliderConfig.cs
+++ b/src/Cordyceps/Core/SliderConfig.cs
@@ -1,0 +1,92 @@
+using System.Globalization;
+
+namespace Cordyceps.Core
+{
+    /// <summary>
+    /// Pure, host-free policy for which Number Slider settings a caller's raw
+    /// <c>min</c>/<c>max</c>/<c>value</c>/<c>decimals</c> arguments should apply, decoupled from the
+    /// Grasshopper <c>GH_NumberSlider</c> host type so it can be unit-tested in <c>Cordyceps.Tests</c>.
+    ///
+    /// <para>Single source of truth shared by <c>gh_canvas(action='add')</c> and
+    /// <c>gh_canvas(action='config')</c>: <c>add</c> historically dropped these four params entirely
+    /// (GHC-7X4B), so a slider always landed at the default 0–1 range / 0.5 value. Both actions now
+    /// compute the same <see cref="SliderConfigPlan"/> and apply it identically, giving <c>add</c>
+    /// parity with <c>config</c>.</para>
+    ///
+    /// <para>"Not provided" sentinels match the tool's parameter defaults exactly:
+    /// <c>min</c>/<c>max</c> = <c>double.NaN</c>, <c>decimals</c> &lt; 0, and a null/empty or
+    /// non-numeric <c>value</c> string. Semantics mirror the original inline <c>ActionConfig</c> code
+    /// so routing both actions through this helper is behavior-preserving for <c>config</c>.</para>
+    ///
+    /// <para>The caller applies the plan in field order — minimum, maximum, decimals, then value —
+    /// because setting the value clamps it to the slider's current range, so the range must be set
+    /// first for an explicit value to survive on a freshly-added (default 0–1) slider.</para>
+    /// </summary>
+    public static class SliderConfig
+    {
+        /// <summary>
+        /// Compute which slider settings to apply from raw tool arguments.
+        /// </summary>
+        /// <param name="min">Requested minimum, or <c>double.NaN</c> if not provided.</param>
+        /// <param name="max">Requested maximum, or <c>double.NaN</c> if not provided.</param>
+        /// <param name="value">Requested value as a string; null/empty or non-numeric means "leave as-is".</param>
+        /// <param name="decimals">Requested decimal places, or a negative value if not provided.</param>
+        public static SliderConfigPlan Plan(double min, double max, string value, int decimals)
+        {
+            bool setMin = !double.IsNaN(min);
+            bool setMax = !double.IsNaN(max);
+            bool setDecimals = decimals >= 0;
+
+            // Mirrors ActionConfig's value handling: apply only when the string parses as a number.
+            // InvariantCulture keeps parsing deterministic regardless of the Rhino host's locale —
+            // MCP/JSON-sourced numeric strings ("3.14") are always invariant, so the original
+            // current-culture parse was a latent locale bug this shared helper removes.
+            double parsedValue = 0;
+            bool setValue = !string.IsNullOrEmpty(value)
+                && double.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands,
+                    CultureInfo.InvariantCulture, out parsedValue);
+
+            return new SliderConfigPlan(
+                setMin, setMin ? (decimal)min : 0m,
+                setMax, setMax ? (decimal)max : 0m,
+                setDecimals, setDecimals ? decimals : 0,
+                setValue, setValue ? (decimal)parsedValue : 0m);
+        }
+    }
+
+    /// <summary>
+    /// The settings <see cref="SliderConfig.Plan"/> determined should be applied to a slider. Each
+    /// <c>Set*</c> flag gates whether the corresponding value is applied; values are pre-converted to
+    /// the <see cref="decimal"/>/<see cref="int"/> types the host slider expects.
+    /// </summary>
+    public sealed class SliderConfigPlan
+    {
+        public SliderConfigPlan(
+            bool setMinimum, decimal minimum,
+            bool setMaximum, decimal maximum,
+            bool setDecimals, int decimals,
+            bool setValue, decimal value)
+        {
+            SetMinimum = setMinimum;
+            Minimum = minimum;
+            SetMaximum = setMaximum;
+            Maximum = maximum;
+            SetDecimals = setDecimals;
+            Decimals = decimals;
+            SetValue = setValue;
+            Value = value;
+        }
+
+        public bool SetMinimum { get; }
+        public decimal Minimum { get; }
+        public bool SetMaximum { get; }
+        public decimal Maximum { get; }
+        public bool SetDecimals { get; }
+        public int Decimals { get; }
+        public bool SetValue { get; }
+        public decimal Value { get; }
+
+        /// <summary>True if the plan applies at least one setting (i.e. the caller passed something).</summary>
+        public bool HasAny => SetMinimum || SetMaximum || SetDecimals || SetValue;
+    }
+}

--- a/src/Cordyceps/Knowledge/GettingStartedGuide.md
+++ b/src/Cordyceps/Knowledge/GettingStartedGuide.md
@@ -36,6 +36,8 @@ gh_inspect(action='status')
 
 **Updating script code**: `gh_script(action='set')` preserves connections for params whose names survive unchanged. If params are renamed or removed, the response includes `lostConnections` — an array directly usable with `gh_wire(action='connect')` to restore wiring.
 
+**Configuring params**: `gh_script(action='configure')` preserves wires the same way — params matching by name keep their connections, and removed/renamed params come back in `lostConnections`. It's a partial update: omit a side (don't pass `inputs` or `outputs`) to leave it untouched, or pass `[]` to explicitly clear that side. So configuring only `inputs` no longer wipes your outputs.
+
 ## Groups
 
 - `gh_canvas(action='group_create', name='...', ids='[...]', color='#FF6B6B')`

--- a/src/Cordyceps/Tools/Unified/GhCanvasTool.Values.cs
+++ b/src/Cordyceps/Tools/Unified/GhCanvasTool.Values.cs
@@ -119,11 +119,14 @@ namespace Cordyceps.Tools.Unified
 
                 if (component is GH_NumberSlider slider)
                 {
-                    if (!double.IsNaN(min)) slider.Slider.Minimum = (decimal)min;
-                    if (!double.IsNaN(max)) slider.Slider.Maximum = (decimal)max;
-                    if (decimals >= 0) slider.Slider.DecimalPlaces = decimals;
-                    if (!string.IsNullOrEmpty(value) && double.TryParse(value, out double val))
-                        slider.SetSliderValue((decimal)val);
+                    // Shares Core.SliderConfig with the 'add' action so both configure a slider
+                    // identically (GHC-7X4B). Range is applied before value because SetSliderValue
+                    // clamps to the current range.
+                    var plan = SliderConfig.Plan(min, max, value, decimals);
+                    if (plan.SetMinimum) slider.Slider.Minimum = plan.Minimum;
+                    if (plan.SetMaximum) slider.Slider.Maximum = plan.Maximum;
+                    if (plan.SetDecimals) slider.Slider.DecimalPlaces = plan.Decimals;
+                    if (plan.SetValue) slider.SetSliderValue(plan.Value);
 
                     if (component is IGH_ActiveObject activeSlider)
                         activeSlider.ExpireSolution(false);

--- a/src/Cordyceps/Tools/Unified/GhCanvasTool.cs
+++ b/src/Cordyceps/Tools/Unified/GhCanvasTool.cs
@@ -31,9 +31,14 @@ namespace Cordyceps.Tools.Unified
                     Name = "add",
                     Description = "Add a component to the canvas",
                     Required = new[] { "type", "x", "y" },
-                    Optional = new[] { "nickname" },
+                    Optional = new[] { "nickname", "min", "max", "value", "decimals" },
                     Example = "action='add', type='Circle', x=200, y=100",
-                    Tips = new[] { "Use 'Category/Name' format for ambiguous names (e.g., 'Curve/Circle')", "Use GUID for guaranteed accuracy" }
+                    Tips = new[] {
+                        "Use 'Category/Name' format for ambiguous names (e.g., 'Curve/Circle')",
+                        "Use GUID for guaranteed accuracy",
+                        "Adding a slider: pass min/max/value/decimals to configure it in one call (e.g. type='slider', min=0, max=100, value=50, decimals=2). Non-slider components ignore these.",
+                        "Set min/max before value: value is clamped to the range. Same slider config as action='config'."
+                    }
                 },
                 ["delete"] = new ActionInfo
                 {
@@ -364,7 +369,7 @@ namespace Cordyceps.Tools.Unified
             // Dispatch to action handler
             return action.ToLowerInvariant() switch
             {
-                "add" => ActionAdd(type, x, y, nickname),
+                "add" => ActionAdd(type, x, y, nickname, min, max, value, decimals),
                 "delete" => ActionDelete(id, ids),
                 "move" => ActionMove(id, x, y, moves),
                 "rename" => ActionRename(id, nickname),
@@ -398,7 +403,8 @@ namespace Cordyceps.Tools.Unified
             };
         }
 
-        private string ActionAdd(string type, double x, double y, string nickname)
+        private string ActionAdd(string type, double x, double y, string nickname,
+            double min, double max, string value, int decimals)
         {
             Core.DebugLog.Info($"gh_canvas add: type='{type}', x={x}, y={y}, nickname='{nickname}'");
 
@@ -445,6 +451,19 @@ namespace Cordyceps.Tools.Unified
 
                     component.Attributes.Pivot = new PointF((float)x, (float)y);
                     doc.AddObject(component, false);
+
+                    // Apply slider configuration when the caller passed min/max/value/decimals on add.
+                    // Non-slider components ignore these params (GHC-7X4B). Shares Core.SliderConfig
+                    // with the 'config' action so add and config configure a slider identically.
+                    if (component is GH_NumberSlider addedSlider)
+                    {
+                        var plan = SliderConfig.Plan(min, max, value, decimals);
+                        if (plan.SetMinimum) addedSlider.Slider.Minimum = plan.Minimum;
+                        if (plan.SetMaximum) addedSlider.Slider.Maximum = plan.Maximum;
+                        if (plan.SetDecimals) addedSlider.Slider.DecimalPlaces = plan.Decimals;
+                        if (plan.SetValue) addedSlider.SetSliderValue(plan.Value);
+                    }
+
                     if (component is IGH_ActiveObject activeAdd)
                         activeAdd.ExpireSolution(false);
 

--- a/src/Cordyceps/Tools/Unified/GhScriptTool.cs
+++ b/src/Cordyceps/Tools/Unified/GhScriptTool.cs
@@ -54,7 +54,13 @@ namespace Cordyceps.Tools.Unified
                     Required = new[] { "id" },
                     Optional = new[] { "inputs", "outputs", "code" },
                     Example = "action='configure', id='abc', inputs='[{\"name\":\"x\",\"type\":\"double\"}]', code='...'",
-                    Tips = new[] { "inputs: [{name, type, access}]", "outputs: [{name, type}]", "types: int, double, bool, string, Point3d, etc.", "Script language is preserved automatically; start code with '#! python 3' or '// #! csharp' to set it explicitly", "A bare unified 'Script' component (no language picked) returns a languageWarning until code starts with a directive — add '#! python 3' or '// #! csharp'" }
+                    Tips = new[] {
+                        "inputs: [{name, type, access}]", "outputs: [{name, type}]", "types: int, double, bool, string, Point3d, etc.",
+                        "Partial update: omit a side (don't pass inputs/outputs) to leave it untouched; pass [] to clear that side. Passing inputs without outputs no longer wipes outputs.",
+                        "Params matching by name keep their wires (like 'set'); renamed/removed params lose connections, reported in lostConnections — pass it to gh_wire(action='connect') to restore",
+                        "Script language is preserved automatically; start code with '#! python 3' or '// #! csharp' to set it explicitly",
+                        "A bare unified 'Script' component (no language picked) returns a languageWarning until code starts with a directive — add '#! python 3' or '// #! csharp'"
+                    }
                 },
                 ["info"] = new ActionInfo
                 {
@@ -246,48 +252,54 @@ namespace Cordyceps.Tools.Unified
                 if (!(component is IGH_Component ghComponent))
                     return ToolHelpers.ErrorResponse("Not an IGH_Component");
 
-                var inputDefs = ParseParamDefs(inputs);
-                var outputDefs = ParseParamDefs(outputs);
+                // Partial-update contract: a side is "provided" only when its JSON arg is non-empty.
+                // Omitted (null/"") => leave that side (and its wires) untouched; "[]" => clear it.
+                var inputDefs = string.IsNullOrEmpty(inputs) ? null : ParseParamDefs(inputs);
+                var outputDefs = string.IsNullOrEmpty(outputs) ? null : ParseParamDefs(outputs);
 
                 bool configured = false;
                 string message = "";
                 string languageWarning = null;
+                List<object> lostConnections = null;
 
                 try
                 {
                     dynamic scriptComp = component;
 
-                    if (component is IGH_VariableParameterComponent varParamComp)
+                    bool anyParamSide = inputDefs != null || outputDefs != null;
+                    if (component is IGH_VariableParameterComponent varParamComp && anyParamSide)
                     {
-                        configured = ConfigureViaVariableParams(ghComponent, varParamComp, inputDefs, outputDefs);
+                        // Sync only the provided sides via the same LCS helper 'set' uses, so
+                        // name-matched params keep their wires and removed-param wires surface in
+                        // lostConnections (GHS-3W9N). Replaces the old "unregister everything" rebuild.
+                        SyncParamsForConfigure(ghComponent, varParamComp, inputDefs, outputDefs, out var lost);
+                        configured = true;
+                        message = $"Parameters configured ({ghComponent.Params.Input.Count} inputs, {ghComponent.Params.Output.Count} outputs)";
 
-                        if (configured)
+                        if (!string.IsNullOrEmpty(code))
                         {
-                            message = $"Parameters configured ({ghComponent.Params.Input.Count} inputs, {ghComponent.Params.Output.Count} outputs)";
-
-                            if (!string.IsNullOrEmpty(code))
+                            try
                             {
-                                try
-                                {
-                                    var finalSource = PreserveLanguageDirective(component, code);
-                                    scriptComp.SetSource(finalSource);
-                                    languageWarning = ScriptDirective.LanguageWarning(component.GetType().Name, finalSource);
-                                    message += ", source set";
-                                }
-                                catch (Exception srcEx)
-                                {
-                                    message += $", source failed: {srcEx.Message}";
-                                }
+                                var finalSource = PreserveLanguageDirective(component, code);
+                                scriptComp.SetSource(finalSource);
+                                languageWarning = ScriptDirective.LanguageWarning(component.GetType().Name, finalSource);
+                                message += ", source set";
                             }
-
-                            // Re-apply type hints AFTER source is set, because SetSource may reset them
-                            ReapplyTypeHints(ghComponent, inputDefs, outputDefs);
-
-                            // Call VariableParameterMaintenance to finalize parameter setup
-                            varParamComp.VariableParameterMaintenance();
-
-                            ghComponent.ExpireSolution(false);
+                            catch (Exception srcEx)
+                            {
+                                message += $", source failed: {srcEx.Message}";
+                            }
                         }
+
+                        // Re-apply type hints + access AFTER source is set, because SetSource may reset them.
+                        ApplyParamHints(ghComponent, inputDefs, outputDefs);
+
+                        // Call VariableParameterMaintenance to finalize parameter setup
+                        varParamComp.VariableParameterMaintenance();
+
+                        ghComponent.ExpireSolution(false);
+
+                        if (lost.Count > 0) lostConnections = lost;
                     }
 
                     if (!configured && !string.IsNullOrEmpty(code))
@@ -347,6 +359,16 @@ namespace Cordyceps.Tools.Unified
                 };
                 if (languageWarning != null)
                     configureResponse["languageWarning"] = languageWarning;
+
+                // Same lostConnections contract as 'set': removed-param wires are returned so the
+                // caller can restore them with gh_wire(action='connect') (GHS-3W9N).
+                if (lostConnections != null)
+                {
+                    configureResponse["lostConnections"] = lostConnections;
+                    configureResponse["reconnectHint"] = "These connections were lost due to parameter changes. "
+                        + "To restore, pass the lostConnections array as 'connections' to gh_wire(action='connect'), "
+                        + "updating targetParam/sourceParam if params were renamed.";
+                }
 
                 return JsonConvert.SerializeObject(configureResponse);
             });
@@ -532,16 +554,13 @@ namespace Cordyceps.Tools.Unified
             var paramList = side == GH_ParameterSide.Input ? ghComponent.Params.Input : ghComponent.Params.Output;
             var existingNames = paramList.Skip(skipCount).Select(p => p.NickName).ToList();
 
-            // Find longest common subsequence — these params keep their connections
-            var matches = ComputeLCS(existingNames, targetNames);
-            var keepIndices = new HashSet<int>(matches.Select(m => m.existIdx));
+            // Pure LCS diff: params whose names appear in both lists are kept (wires preserved);
+            // the rest are removed and missing target names inserted. Shared with the 'configure' path.
+            var plan = Core.ParamSyncPlan.Compute(existingNames, targetNames);
 
-            // Step 1: Remove params not in LCS (iterate backwards to avoid index shift issues)
-            for (int i = existingNames.Count - 1; i >= 0; i--)
+            // Step 1: Remove params not kept (descending indices — shift-safe). Capture wires first.
+            foreach (int i in plan.RemoveExistingIndicesDescending)
             {
-                if (keepIndices.Contains(i))
-                    continue;
-
                 var param = paramList[i + skipCount];
 
                 // Capture connections before removal
@@ -587,20 +606,13 @@ namespace Cordyceps.Tools.Unified
                     ghComponent.Params.UnregisterOutputParameter(param);
             }
 
-            // After removal, remaining custom params (past skipCount) are LCS elements in order.
-            // Step 2: Insert new params at the correct positions.
-            // Walk through target list left-to-right. For positions covered by LCS, the param
-            // is already in place. For other positions, insert a new param.
-            // Since we process left-to-right, actualIdx = t + skipCount accounts for
-            // all previous insertions automatically.
-            var lcsTargetIndices = new HashSet<int>(matches.Select(m => m.targetIdx));
-
-            for (int t = 0; t < targetNames.Count; t++)
+            // After removal, the kept custom params (past skipCount) are the LCS elements in order.
+            // Step 2: Insert new params at their target positions. Insertions are ascending, so
+            // applying them left-to-right makes actualIdx = TargetIndex + skipCount land each
+            // correctly (earlier insertions account for the later ones automatically).
+            foreach (var insertion in plan.Insertions)
             {
-                if (lcsTargetIndices.Contains(t))
-                    continue; // Already in place from existing params
-
-                int actualIdx = t + skipCount;
+                int actualIdx = insertion.TargetIndex + skipCount;
                 if (!varParamComp.CanInsertParameter(side, actualIdx))
                 {
                     DebugLog.Warn($"[SyncParamSide] Cannot insert {side} param at index {actualIdx}");
@@ -614,50 +626,15 @@ namespace Cordyceps.Tools.Unified
                     continue;
                 }
 
-                newParam.Name = targetNames[t];
-                newParam.NickName = targetNames[t];
+                newParam.Name = insertion.Name;
+                newParam.NickName = insertion.Name;
 
-                DebugLog.Debug($"[SyncParamSide] Inserting {side} '{targetNames[t]}' at index {actualIdx}");
+                DebugLog.Debug($"[SyncParamSide] Inserting {side} '{insertion.Name}' at index {actualIdx}");
                 if (side == GH_ParameterSide.Input)
                     ghComponent.Params.RegisterInputParam(newParam, actualIdx);
                 else
                     ghComponent.Params.RegisterOutputParam(newParam, actualIdx);
             }
-        }
-
-        /// <summary>
-        /// Compute the Longest Common Subsequence of two string lists.
-        /// Returns pairs of (index in existing, index in target) for matched elements.
-        /// </summary>
-        private static List<(int existIdx, int targetIdx)> ComputeLCS(List<string> existing, List<string> target)
-        {
-            int m = existing.Count, n = target.Count;
-            var dp = new int[m + 1, n + 1];
-
-            for (int i = 1; i <= m; i++)
-                for (int j = 1; j <= n; j++)
-                    dp[i, j] = existing[i - 1] == target[j - 1]
-                        ? dp[i - 1, j - 1] + 1
-                        : Math.Max(dp[i - 1, j], dp[i, j - 1]);
-
-            // Backtrack to find matched pairs
-            var matches = new List<(int, int)>();
-            int x = m, y = n;
-            while (x > 0 && y > 0)
-            {
-                if (existing[x - 1] == target[y - 1])
-                {
-                    matches.Add((x - 1, y - 1));
-                    x--; y--;
-                }
-                else if (dp[x - 1, y] >= dp[x, y - 1])
-                    x--;
-                else
-                    y--;
-            }
-
-            matches.Reverse();
-            return matches;
         }
 
         /// <summary>
@@ -766,131 +743,87 @@ namespace Cordyceps.Tools.Unified
         }
 
         /// <summary>
-        /// Re-apply type hints to parameters after source has been set
-        /// SetSource may reset output type hints, so we need to reapply them
+        /// Configure-path parameter sync. Reshapes only the <em>provided</em> sides (a null def list
+        /// means "side omitted — leave it and its wires untouched"; an empty list means "clear that
+        /// side") to match the given defs <em>by name</em>, routing through the same LCS-based
+        /// <see cref="SyncParamSide"/> that <c>set</c> uses. Params whose names are unchanged keep
+        /// their wires; wires on removed params are captured into <paramref name="lostConnections"/>
+        /// in the gh_wire(action='connect')-ready shape. This replaces the previous
+        /// unregister-everything rebuild that destroyed all wires (GHS-3W9N).
+        ///
+        /// <para>Type hints and access are NOT set here — <see cref="ApplyParamHints"/> applies them
+        /// after <c>SetSource</c>, which can reset type hints.</para>
         /// </summary>
-        private void ReapplyTypeHints(IGH_Component ghComponent, List<ParamDef> inputDefs, List<ParamDef> outputDefs)
+        private void SyncParamsForConfigure(IGH_Component ghComponent, IGH_VariableParameterComponent varParamComp,
+            List<ParamDef> inputDefs, List<ParamDef> outputDefs, out List<object> lostConnections)
         {
-            DebugLog.Debug($"ReapplyTypeHints: {inputDefs.Count} inputs, {outputDefs.Count} outputs");
+            lostConnections = new List<object>();
 
-            // Re-apply input type hints
-            for (int i = 0; i < inputDefs.Count && i < ghComponent.Params.Input.Count; i++)
+            if (inputDefs != null)
             {
-                var def = inputDefs[i];
-                var param = ghComponent.Params.Input[i];
-                if (!string.IsNullOrEmpty(def.Type))
-                {
-                    SetParameterTypeHint(param, def.Type);
-                }
+                var targetNames = inputDefs.Select(d => d.Name).ToList();
+                SyncParamSide(ghComponent, varParamComp, GH_ParameterSide.Input, targetNames, 0, out var inputLost);
+                lostConnections.AddRange(inputLost);
             }
 
-            // Re-apply output type hints (skip the first 'out' parameter if present)
-            // Output parameters start at index 1 (index 0 is 'out')
-            for (int i = 0; i < outputDefs.Count; i++)
+            if (outputDefs != null)
             {
-                var def = outputDefs[i];
-                // Output index is i+1 because index 0 is the built-in 'out' parameter
-                int paramIndex = i + 1;
-                if (paramIndex < ghComponent.Params.Output.Count)
-                {
-                    var param = ghComponent.Params.Output[paramIndex];
-                    if (!string.IsNullOrEmpty(def.Type))
-                    {
-                        DebugLog.Debug($"ReapplyTypeHints: Output '{param.Name}' -> type '{def.Type}'");
-                        SetParameterTypeHint(param, def.Type);
-                    }
-                }
+                // skipCount=1: preserve the built-in index-0 'out' output (mirrors the 'set' path).
+                var targetNames = outputDefs.Select(d => d.Name).ToList();
+                SyncParamSide(ghComponent, varParamComp, GH_ParameterSide.Output, targetNames, 1, out var outputLost);
+                lostConnections.AddRange(outputLost);
             }
+
+            varParamComp.VariableParameterMaintenance();
+            DebugLog.Info($"SyncParamsForConfigure complete: {ghComponent.Params.Input.Count} inputs, {ghComponent.Params.Output.Count} outputs, {lostConnections.Count} wires lost");
         }
 
-        private bool ConfigureViaVariableParams(IGH_Component ghComponent, IGH_VariableParameterComponent varParamComp, List<ParamDef> inputDefs, List<ParamDef> outputDefs)
+        /// <summary>
+        /// Apply type hints (both sides) and access modes (inputs only) from the provided defs to the
+        /// component's params by position. A null def list means the side was omitted — leave it
+        /// alone (partial-update contract). After <see cref="SyncParamsForConfigure"/> the params are
+        /// in def order, so def[i] maps to input[i] / output[i+1] (index 0 is the built-in 'out').
+        /// Called after <c>SetSource</c>, which can reset type hints.
+        /// </summary>
+        private void ApplyParamHints(IGH_Component ghComponent, List<ParamDef> inputDefs, List<ParamDef> outputDefs)
         {
-            try
+            if (inputDefs != null)
             {
-                DebugLog.Info($"ConfigureViaVariableParams: {inputDefs.Count} inputs, {outputDefs.Count} outputs");
-
-                // Remove existing inputs
-                while (ghComponent.Params.Input.Count > 0)
+                for (int i = 0; i < inputDefs.Count && i < ghComponent.Params.Input.Count; i++)
                 {
-                    var param = ghComponent.Params.Input[ghComponent.Params.Input.Count - 1];
-                    varParamComp.CanRemoveParameter(GH_ParameterSide.Input, ghComponent.Params.Input.Count - 1);
-                    ghComponent.Params.UnregisterInputParameter(param);
-                }
-
-                // Remove outputs except first ('out')
-                while (ghComponent.Params.Output.Count > 1)
-                {
-                    var param = ghComponent.Params.Output[ghComponent.Params.Output.Count - 1];
-                    varParamComp.CanRemoveParameter(GH_ParameterSide.Output, ghComponent.Params.Output.Count - 1);
-                    ghComponent.Params.UnregisterOutputParameter(param);
-                }
-
-                // Add inputs with type hints
-                foreach (var def in inputDefs)
-                {
-                    if (varParamComp.CanInsertParameter(GH_ParameterSide.Input, ghComponent.Params.Input.Count))
+                    var def = inputDefs[i];
+                    var param = ghComponent.Params.Input[i];
+                    if (!string.IsNullOrEmpty(def.Type))
+                        SetParameterTypeHint(param, def.Type);
+                    if (!string.IsNullOrEmpty(def.Access))
                     {
-                        // Use CreateParameter to get the component's native parameter type
-                        var newParam = varParamComp.CreateParameter(GH_ParameterSide.Input, ghComponent.Params.Input.Count);
-                        if (newParam != null)
+                        switch (def.Access.ToLowerInvariant())
                         {
-                            newParam.Name = def.Name;
-                            newParam.NickName = def.Name;
-
-                            // Set type hint BEFORE registering (for script components)
-                            if (!string.IsNullOrEmpty(def.Type))
-                            {
-                                SetParameterTypeHint(newParam, def.Type);
-                            }
-
-                            // Set access mode
-                            if (!string.IsNullOrEmpty(def.Access))
-                            {
-                                switch (def.Access.ToLowerInvariant())
-                                {
-                                    case "list": newParam.Access = GH_ParamAccess.list; break;
-                                    case "tree": newParam.Access = GH_ParamAccess.tree; break;
-                                    default: newParam.Access = GH_ParamAccess.item; break;
-                                }
-                            }
-
-                            ghComponent.Params.RegisterInputParam(newParam);
-                            DebugLog.Debug($"Added input '{def.Name}' type='{def.Type}' access='{def.Access}'");
+                            case "list": param.Access = GH_ParamAccess.list; break;
+                            case "tree": param.Access = GH_ParamAccess.tree; break;
+                            default: param.Access = GH_ParamAccess.item; break;
                         }
                     }
                 }
-
-                // Add outputs with type hints
-                foreach (var def in outputDefs)
-                {
-                    if (varParamComp.CanInsertParameter(GH_ParameterSide.Output, ghComponent.Params.Output.Count))
-                    {
-                        var newParam = varParamComp.CreateParameter(GH_ParameterSide.Output, ghComponent.Params.Output.Count);
-                        if (newParam != null)
-                        {
-                            newParam.Name = def.Name;
-                            newParam.NickName = def.Name;
-
-                            // Set type hint for output too
-                            if (!string.IsNullOrEmpty(def.Type))
-                            {
-                                SetParameterTypeHint(newParam, def.Type);
-                            }
-
-                            ghComponent.Params.RegisterOutputParam(newParam);
-                            DebugLog.Debug($"Added output '{def.Name}' type='{def.Type}'");
-                        }
-                    }
-                }
-
-                varParamComp.VariableParameterMaintenance();
-                DebugLog.Info($"ConfigureViaVariableParams complete: {ghComponent.Params.Input.Count} inputs, {ghComponent.Params.Output.Count} outputs");
-                return true;
             }
-            catch (Exception ex)
+
+            if (outputDefs != null)
             {
-                DebugLog.Error($"ConfigureViaVariableParams failed: {ex.Message}");
-                return false;
+                // Output params start at index 1 (index 0 is the built-in 'out').
+                for (int i = 0; i < outputDefs.Count; i++)
+                {
+                    int paramIndex = i + 1;
+                    if (paramIndex < ghComponent.Params.Output.Count)
+                    {
+                        var def = outputDefs[i];
+                        var param = ghComponent.Params.Output[paramIndex];
+                        if (!string.IsNullOrEmpty(def.Type))
+                        {
+                            DebugLog.Debug($"ApplyParamHints: Output '{param.Name}' -> type '{def.Type}'");
+                            SetParameterTypeHint(param, def.Type);
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Two related gh-tool bugfixes shipping under **v1.4.12**. Each is backed by a pure, host-free decision helper with unit tests; the live-host glue is queued for operator verification.

## Fixes

### `gh_canvas(action='add')` now applies slider min/max/value/decimals (GHC-7X4B)
Adding a Number Slider with `gh_canvas(action='add', type='slider', min=0, max=100, value=50, decimals=2)` previously ignored all four params — the `add` dispatcher forwarded only `type/x/y/nickname`, so the slider always landed at the default 0–1 range / 0.5 value, forcing a second `config` call. They're now applied on add (range first, then value so it isn't clamped to the old range), giving `add` parity with `config`. Both share one `Core.SliderConfig` policy (which also fixes a latent locale bug by parsing the value with InvariantCulture). Non-slider components ignore these params.

### `gh_script(action='configure')` now preserves wires (GHS-3W9N)
`configure` previously unregistered *every* input/output param and re-registered them from scratch, silently dropping **all** wires — even on name-unchanged params — and reported nothing lost. It now reshapes params by name via the same LCS sync `set` already used (`Core.ParamSyncPlan`): name-matched params keep their connections, and wires on renamed/removed params are returned in a `lostConnections` array (with a `reconnectHint`) directly usable with `gh_wire(action='connect')`. `configure` is now also a **partial update** — omit a side to leave it untouched, or pass `[]` to clear it (previously configuring only `inputs` wiped all `outputs`).

## Testing
- New pure helpers `Core/SliderConfig.cs` + `Core/ParamSyncPlan.cs`, linked host-free into the test project.
- **29 new unit tests** (incl. both regression cases); **224 total green**, Release build clean (0 warnings).
- Host glue that no unit test can reach (live `GH_NumberSlider` apply; live `IGH_Param` reshape) queued as **VRF-004 / VRF-005** in the operator-verification queue (`operator_verification_required: false` — non-blocking, an honesty record for live-Rhino verification before/after merge).

## Docs
CHANGELOG `[1.4.12]`, GettingStartedGuide, both ActionInfo tip blocks, and the governance change-log entry — all updated.

## Review
- **Critic** (cumulative @ base, extended to HEAD via `verify-resolutions` chain): **0 blocking**; all 3 warnings + 3 notes from the cumulative pass resolved.
- **Independent PR review** (Opus): **0 blocking, 0 warnings, 0 notes**; audited the Critic record (6 adversarial spot-checks, all passed).

## Release / flow
This is the **last main-targeted feature PR** under the current flow. After merge, `./scripts/release.sh 1.4.12` cuts the release (version bump + tag + GitHub Release + Yak). Then we switch to gitflow (`develop` as default) and protect `main`.

## Collateral (not shippable code)
- `docs/upstream-rhino-scriptcomponent-languagespec.md` — a labeled draft McNeel bug report for **GHS-4D8M** (the upstream Rhino ScriptComponent language-wipe; out of scope here, stays open).
- **GHC-2N8K** filed (open) for the Critic's de-dup NOTE on the host-bound slider-apply block.
