### PR TITLE
docs: retitle rhino ScriptComponent languagespec (cherry-pick from develop)

### DIFF
--- a/docs/upstream-rhino-scriptcomponent-languagespec.md
+++ b/docs/upstream-rhino-scriptcomponent-languagespec.md
@@ -1,6 +1,6 @@
 # Upstream bug report (McNeel): unified `ScriptComponent` silently loses its language on source replacement
 
-This is a **draft to file with McNeel** (Rhino/Grasshopper), not a Cordyceps bug. Cordyceps
+This is an issue with Rhino/Grasshopper), not a Cordyceps bug. Cordyceps
 already mitigates the reachable cases (see *Cordyceps mitigation* below); the root cause is in
 Rhino 8's `RhinoCodePluginGH.Components.ScriptComponent`. Backlog: `GHS-4D8M`. Originally surfaced
 in Cordyceps issue [#15](https://github.com/brookstalley/cordyceps/issues/15).

--- a/docs/upstream-rhino-scriptcomponent-languagespec.md
+++ b/docs/upstream-rhino-scriptcomponent-languagespec.md
@@ -1,12 +1,4 @@
-# Upstream bug report (McNeel): unified `ScriptComponent` silently loses its language on source replacement
-
-This is an issue with Rhino/Grasshopper), not a Cordyceps bug. Cordyceps
-already mitigates the reachable cases (see *Cordyceps mitigation* below); the root cause is in
-Rhino 8's `RhinoCodePluginGH.Components.ScriptComponent`. Backlog: `GHS-4D8M`. Originally surfaced
-in Cordyceps issue [#15](https://github.com/brookstalley/cordyceps/issues/15).
-
-**Where to file:** McNeel Discourse (https://discourse.mcneel.com/, *Grasshopper Developer* /
-*Scripting* category) or, if you have an account, YouTrack (https://mcneel.myjetbrains.com/).
+# Unified `ScriptComponent` silently loses its language on source replacement
 
 ---
 

--- a/src/Cordyceps.Tests/AssemblyInfo.cs
+++ b/src/Cordyceps.Tests/AssemblyInfo.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+// Disable xUnit test-collection parallelization.
+//
+// Several tests assert timing/concurrency contracts (InFlightRequests drain + count,
+// DocumentLock, CommandStats) by waiting on thread-pool continuations within a bounded
+// budget. With xUnit's default parallel collections, those tests contend for the 2-core
+// CI runner's thread pool — sibling tests doing Thread.Sleep / blocking waits can starve a
+// removal continuation past its budget, so `build-test` flakes (it passed on #21, failed
+// twice on #22 with no relevant code change). A flaky required check is unacceptable for the
+// strict main-protection gate, so we trade a little wall-clock for determinism: the suite is
+// tiny (224 tests, sub-second), and serial execution gives the timing tests an uncontended
+// pool. No assertion is weakened — the contracts still run, just without the contention that
+// made a valid assertion flaky.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
Cherry-picks `docs/upstream-rhino-scriptcomponent-languagespec.md` from `develop` onto `main`, plus the flake fix needed to get past `main`'s required gate.

## Files

1. **`docs/upstream-rhino-scriptcomponent-languagespec.md`** — the requested cherry-pick. Brings the two file-isolated `develop` commits (`e1d29ff`, `f52113b`) that retitle the doc, dropping the "draft bug report to file with McNeel" framing. Identical to `develop`.
2. **`src/Cordyceps.Tests/AssemblyInfo.cs`** — `[assembly: CollectionBehavior(DisableTestParallelization = true)]`, brought from `develop` (commit `0eb1bb0`). Identical to `develop`.

## Why the second file

`main`'s required `build-test` check is **flaky on its own** (e.g. the `Release v1.4.12` push run failed): timing/concurrency tests (`InFlightRequests` drain+count, `DocumentLock`, `CommandStats`) contend for the 2-core CI runner's thread pool under xUnit's default parallel collections, starving a removal continuation past its budget. `develop` already fixed this by disabling test parallelization, but that fix never reached `main`. Without it, this PR (and every PR to `main`) flakes on a valid assertion. No assertion is weakened — the contracts still run, serially, on an uncontended pool.