### PR TITLE
docs: lead README install with Rhino Package Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Cordyceps will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+
+- **README install instructions** - Documented installation via the Rhino Package Manager (run `PackageManager`, search "Cordyceps", install) as the recommended method, with manual `.gha` download kept as the secondary option. Clarified that file-unblocking (Windows) / quarantine-clearing (macOS) is only needed for manual installs, and added the macOS `xattr` quarantine-clear command.
+
 ## [1.4.12] - 2026-06-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -19,12 +19,26 @@
 
 ## Installation
 
-1. **[Download Cordyceps.gha](https://github.com/brookstalley/cordyceps/raw/main/releases/Cordyceps.gha)**
+### Rhino Package Manager (recommended)
+
+1. In Rhino 8, run the **`PackageManager`** command (or *Tools → Package Manager*)
+2. Search for **Cordyceps** and click **Install**
+3. Restart Rhino
+
+The Package Manager downloads the plugin, places it in the right folder, and unblocks it for you — and future updates are one click.
+
+### Manual install
+
+1. **[Download Cordyceps.gha](https://github.com/brookstalley/cordyceps/raw/main/releases/Cordyceps.gha)** (or grab it from the [latest release](https://github.com/brookstalley/cordyceps/releases/latest))
 
 2. Copy to your Grasshopper components folder:
    *File → Special Folders → Components Folder*
 
-3. **Windows users**: Right-click the file → Properties → check "Unblock" → OK
+3. Unblock the file so Rhino will load it:
+   - **Windows**: right-click → Properties → check "Unblock" → OK
+   - **macOS**: clear the quarantine flag (e.g. `xattr -dr com.apple.quarantine <path-to-Cordyceps.gha>`)
+
+4. Restart Rhino
 
 ## Usage
 
@@ -154,7 +168,7 @@ Browse the documentation directly: [`src/Cordyceps/Knowledge/`](src/Cordyceps/Kn
 
 | Problem | Solution |
 |---------|----------|
-| Plugin won't load | Verify Rhino 8.21+. Unblock the .gha file (Windows) or clear quarantine (macOS). |
+| Plugin won't load | Verify Rhino 8.21+. If you installed manually, unblock the .gha file (Windows) or clear its quarantine flag (macOS) — the Package Manager does this for you. |
 | Can't connect | Ensure Cordyceps component is on canvas. Check the port. |
 | Claude Desktop can't connect | Ensure Node.js is installed. Check Rhino is running with Cordyceps. Restart Claude Desktop after config changes. |
 | Component not found | Use `gh_canvas(action='search', query='...')` to find exact names. |


### PR DESCRIPTION
## Summary

Refreshes the README installation guidance and records it in the changelog.

- **README** — Installation now leads with the **Rhino Package Manager** as the recommended method (`PackageManager` command → search "Cordyceps" → Install → restart), with manual `.gha` download demoted to a clearly-labeled secondary option.
- Clarified that file unblocking (Windows) / quarantine clearing (macOS, with the `xattr -dr com.apple.quarantine` command) is **only needed for manual installs** — the Package Manager handles it. Updated the matching troubleshooting row.
- Added a `## [Unreleased]` section to CHANGELOG.md recording the change.

## Verification

- Yak package name confirmed as `cordyceps` (from `manifest.yml`) — what users search for in the Package Manager.
- README's "7 tools / 110+ actions" claim re-verified accurate (112 `ActionInfo` entries across the unified tools).
- Build command in README left as-is: plain `dotnet build` works because the csproj pins `<Configurations>Release</Configurations>` (Release is the default/only config).

## Review gates

Doc-only PR — both changed files are `.md`. Cumulative-Critic and PR-reviewer gates skipped per `prawduct-hook check-pr-doc-only` (exit 0).